### PR TITLE
FireEye Red Team countermeasures

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ A curated list of awesome YARA rules, tools, and resources. Inspired by [awesome
     - Collection of YARA and Snort rules from IOCs collected by ESET researchers. There's about a dozen YARA Rules to glean from in this repo, search for file extension .yar. This repository is seemingly updated on a roughly monthly interval. New IOCs are often mentioned on the [ESET WeLiveSecurity Blog](https://www.welivesecurity.com/).
 * [Fidelis Rules](https://github.com/fideliscyber/indicators/tree/master/yararules)
     - You can find a half dozen YARA rules in Fidelis Cyber's IOC repository. They update this repository on a roughly quarterly interval. Complete blog content is also available in this repository.
+* [FireEye](https://github.com/fireeye/red_team_tool_countermeasures)
+    - FireEye Red Team countermeasures released after a state attack
 * [Florian Roth Rules](https://github.com/Neo23x0/signature-base/tree/master/yara) :eyes: :gem:
     - Florian Roth's signature base is a frequently updated collection of IOCs and YARA rules that cover a wide range of threats. There are dozens of rules which are actively maintained. Watch the repository to see rules evolve over time to address false potives / negatives.
 * [Florian Roth's IDDQD Rule](https://gist.github.com/Neo23x0/f1bb645a4f715cb499150c5a14d82b44)


### PR DESCRIPTION
Hello,
Following a state attack, FireEye published YARA rules against its Red Teams tools.
I didn't put a caption because I didn't know what to put.